### PR TITLE
Use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
-                  password: ${{ secrets.CR_PAT }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Extract metadata (tags, labels) for app image
               id: meta-app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker publishing workflow to use standard GitHub credentials for container registry authentication, improving credential management for internal deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->